### PR TITLE
Fix a minor mistake

### DIFF
--- a/HintServiceMeow/Core/Utilities/Patch/Patches.cs
+++ b/HintServiceMeow/Core/Utilities/Patch/Patches.cs
@@ -83,7 +83,7 @@ namespace HintServiceMeow.Core.Utilities.Patch
             }
             catch (Exception ex)
             {
-                LogTool.Error(ex);
+                Logger.Instance.Error(ex);
             }
 
             return false;
@@ -104,7 +104,7 @@ namespace HintServiceMeow.Core.Utilities.Patch
             }
             catch (Exception ex)
             {
-                LogTool.Error(ex);
+                Logger.Instance.Error(ex);
             }
 
             return false;

--- a/HintServiceMeow/HintServiceMeow.csproj
+++ b/HintServiceMeow/HintServiceMeow.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;EXILED</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Fix a minor mistake that cause Exiled version unable to compile successfully.