### PR TITLE
Lower or Upper

### DIFF
--- a/HintServiceMeow/Core/Models/HintContent/StringContent.cs
+++ b/HintServiceMeow/Core/Models/HintContent/StringContent.cs
@@ -3,7 +3,27 @@
 namespace HintServiceMeow.Core.Models.HintContent
 {
     public class StringContent : AbstractHintContent
-    {
+    {       
+        private static readonly Regex CoreRegex = new("(<.*?>)");
+        
+        private static string AddLower(string old)
+        {
+            var s = CoreRegex.Split(old);
+            string txt = "";
+            foreach (var i in s)
+            {
+                if (CoreRegex.IsMatch(i)) txt += i;
+                else
+                    foreach (var p in i)
+                    {
+                        if (IsUpper(p))
+                            txt += $"<uppercase>{p}</uppercase>";
+                        else
+                            txt += p;
+                    }
+            }
+            return $"<lowercase>{txt}</lowercase>";
+        }
         private string _text = string.Empty;
 
         public string Text
@@ -25,7 +45,7 @@ namespace HintServiceMeow.Core.Models.HintContent
             this.Text = content;
         }
 
-        public override string GetText() => Text;
+        public override string GetText() => AddLower(Text);
 
         public override void TryUpdate(ContentUpdateArg ev) { }
     }


### PR DESCRIPTION
因SL的Hint大小写不分，应通过正则表达式判断，手动添加<lowercase>/<uppercase>富文本标签来修复该问题