### PR TITLE
Add test coroutine doubles and inject runner into PlayerDisplay unit tests

### DIFF
--- a/HintServiceMeow.Tests/Core/Utilities/PlayerDisplayTests.cs
+++ b/HintServiceMeow.Tests/Core/Utilities/PlayerDisplayTests.cs
@@ -21,6 +21,7 @@ namespace HintServiceMeow.Tests.Core.Utilities
         private TestCompatibilityAdaptor adaptor = null!;
         private TestHintParser parser = null!;
         private TestPlayerContext context = null!;
+        private TestCoroutineRunner coroutineRunner = null!;
         private PlayerDisplay display = null!;
 
         [TestInitialize]
@@ -31,8 +32,9 @@ namespace HintServiceMeow.Tests.Core.Utilities
             adaptor = new TestCompatibilityAdaptor();
             parser = new TestHintParser();
             context = new TestPlayerContext { IsStillValid = false };
+            coroutineRunner = new TestCoroutineRunner();
 
-            display = new PlayerDisplay(context, updateScheduler: scheduler, adaptor: adaptor, hintParser: parser);
+            display = new PlayerDisplay(context, updateScheduler: scheduler, adaptor: adaptor, hintParser: parser, coroutineRunner: coroutineRunner);
         }
 
         [TestCleanup]
@@ -50,6 +52,25 @@ namespace HintServiceMeow.Tests.Core.Utilities
             {
                 _ = new PlayerDisplay(null!);
             });
+        }
+
+        [TestMethod]
+        // Verify constructor starts the internal update coroutine using injected runner.
+        public void Constructor_ShouldStartCoroutine_WhenRunnerInjected()
+        {
+            Assert.AreEqual(1, coroutineRunner.StartedRoutines.Count);
+            Assert.IsTrue(coroutineRunner.LastCoroutine.IsRunning);
+            Assert.IsFalse(coroutineRunner.LastCoroutine.IsKilled);
+        }
+
+        [TestMethod]
+        // Verify destruct stops the started coroutine.
+        public void Destruct_ShouldKillStartedCoroutine()
+        {
+            ((IDestructible)display).Destruct();
+
+            Assert.IsTrue(coroutineRunner.LastCoroutine.IsKilled);
+            Assert.IsFalse(coroutineRunner.LastCoroutine.IsRunning);
         }
 
         [TestMethod]

--- a/HintServiceMeow.Tests/Core/Utilities/TestDoubles/PlayerDisplayTestDoubles.cs
+++ b/HintServiceMeow.Tests/Core/Utilities/TestDoubles/PlayerDisplayTestDoubles.cs
@@ -79,6 +79,51 @@ namespace HintServiceMeow.Tests.Core.Utilities.TestDoubles
     }
 
     /// <summary>
+    /// Test coroutine implementation with controllable running state.
+    /// </summary>
+    internal sealed class TestCoroutine : ICoroutine
+    {
+        public bool IsRunning { get; private set; } = true;
+
+        public bool IsPaused { get; private set; }
+
+        public bool IsKilled { get; private set; }
+
+        public void Kill()
+        {
+            IsKilled = true;
+            IsRunning = false;
+        }
+
+        public void Pause()
+        {
+            IsPaused = true;
+        }
+
+        public void Resume()
+        {
+            IsPaused = false;
+        }
+    }
+
+    /// <summary>
+    /// Coroutine runner test double that records started routines.
+    /// </summary>
+    internal sealed class TestCoroutineRunner : ICoroutineRunner
+    {
+        public List<IEnumerator<float>> StartedRoutines { get; } = [];
+
+        public TestCoroutine LastCoroutine { get; private set; } = null!;
+
+        public ICoroutine StartCoroutine(IEnumerator<float> routine)
+        {
+            StartedRoutines.Add(routine);
+            LastCoroutine = new TestCoroutine();
+            return LastCoroutine;
+        }
+    }
+
+    /// <summary>
     /// Compatibility adaptor test double that records forwarding calls.
     /// </summary>
     internal sealed class TestCompatibilityAdaptor : ICompatibilityAdaptor, IDestructible

--- a/HintServiceMeow/Core/Utilities/PlayerDisplay.cs
+++ b/HintServiceMeow/Core/Utilities/PlayerDisplay.cs
@@ -83,7 +83,7 @@
             });
 
             // Start the main coroutine on main thread
-            this.coroutineRunner.StartCoroutine(CoroutineMethod());
+            coroutine = this.coroutineRunner.StartCoroutine(CoroutineMethod());
         }
 
         private PlayerDisplay(ReferenceHub referenceHub)


### PR DESCRIPTION
### Motivation
- Remove Unity runtime dependency from unit tests by providing test implementations of `ICoroutine` and `ICoroutineRunner` so `PlayerDisplay` coroutine behavior can be asserted deterministically.

### Description
- Retain the coroutine handle returned by `StartCoroutine` in `PlayerDisplay` by assigning `coroutine = this.coroutineRunner.StartCoroutine(CoroutineMethod());` so `Destruct()` can stop it.
- Add `TestCoroutine` and `TestCoroutineRunner` test doubles to `HintServiceMeow.Tests/Core/Utilities/TestDoubles/PlayerDisplayTestDoubles.cs` implementing `ICoroutine`/`ICoroutineRunner` and recording started routines.
- Update `PlayerDisplayTests` to inject `TestCoroutineRunner` into `PlayerDisplay` and add tests that assert the coroutine is started at construction and killed on `Destruct()` (`Constructor_ShouldStartCoroutine_WhenRunnerInjected` and `Destruct_ShouldKillStartedCoroutine`).

### Testing
- Attempted to run `dotnet test HintServiceMeow.Tests/HintServiceMeow.Tests.csproj`, but the `dotnet` CLI is not available in this environment, so automated tests were not executed (failed due to missing `dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a27a290b4083269b1eef6dd99faeda)